### PR TITLE
Fix for issue #99 - Shallow copy methods (and tests) for categories

### DIFF
--- a/MyHome.DataClasses/Extensions.cs
+++ b/MyHome.DataClasses/Extensions.cs
@@ -6,7 +6,7 @@
     public static class Extensions
     {
         #region Expense Extensions
-        
+
         /// <summary>
         /// Makes a shallow copy of the expense
         /// </summary>
@@ -16,7 +16,7 @@
         {
             return new Expense(orginalExpense.Amount, orginalExpense.Date,
                 orginalExpense.Category, orginalExpense.Method, orginalExpense.Comments, orginalExpense.Id)
-            { CategoryId = orginalExpense.CategoryId, PaymentMethodId = orginalExpense.PaymentMethodId};
+            { CategoryId = orginalExpense.CategoryId, PaymentMethodId = orginalExpense.PaymentMethodId };
         }
 
         #endregion
@@ -32,7 +32,35 @@
         {
             return new Income(orginalIncome.Amount, orginalIncome.Date,
                 orginalIncome.Category, orginalIncome.Method, orginalIncome.Comments, orginalIncome.Id)
-            { CategoryId = orginalIncome.CategoryId, PaymentMethodId = orginalIncome.PaymentMethodId};
+            { CategoryId = orginalIncome.CategoryId, PaymentMethodId = orginalIncome.PaymentMethodId };
+        }
+
+        #endregion
+
+        #region ExpenseCategory Extensions
+
+        /// <summary>
+        /// Makes a shallow copy of the ExpenseCategory
+        /// </summary>
+        /// <param name="originalExpenseCategory">The ExpenseCategory being copied</param>
+        /// <returns>A shallow copy of the ExpenseCategory</returns>
+        public static ExpenseCategory Copy(this ExpenseCategory originalExpenseCategory)
+        {
+            return new ExpenseCategory(originalExpenseCategory.Id, originalExpenseCategory.Name);
+        }
+
+        #endregion
+
+        #region IncomeCategory Extensions
+
+        /// <summary>
+        /// Makes a shallow copy of the IncomeCategory
+        /// </summary>
+        /// <param name="orginalIncomeCategory">The IncomeCategory being copied</param>
+        /// <returns>A shallow copy of the IncomeCategory</returns>
+        public static IncomeCategory Copy(this IncomeCategory orginalIncomeCategory)
+        {
+            return new IncomeCategory(orginalIncomeCategory.Id, orginalIncomeCategory.Name);
         }
 
         #endregion

--- a/MyHome.DataClasses/Extensions.cs
+++ b/MyHome.DataClasses/Extensions.cs
@@ -64,5 +64,19 @@
         }
 
         #endregion
+
+        #region PaymentMethod Extensions
+
+        /// <summary>
+        /// Makes a shallow copy of the PaymentMethod
+        /// </summary>
+        /// <param name="orginalPaymentMethod">The PaymentMethod being copied</param>
+        /// <returns>A shallow copy of the PaymentMethod</returns>
+        public static PaymentMethod Copy(this PaymentMethod orginalPaymentMethod)
+        {
+            return new PaymentMethod(orginalPaymentMethod.Id, orginalPaymentMethod.Name);
+        }
+
+        #endregion
     }
 }

--- a/Tests/Unit Tests/MyHome.DataClasses.Tests/ExtensionsTests.cs
+++ b/Tests/Unit Tests/MyHome.DataClasses.Tests/ExtensionsTests.cs
@@ -93,5 +93,21 @@ namespace MyHome.DataClasses.Tests
             Assert.IsTrue(first.Equals(second));
             Assert.IsTrue(second.Equals(first));
         }
+
+        [TestMethod]
+        public void PaymentMethod_Copy()
+        {
+            var first = new PaymentMethod
+            {
+                Id = 1,
+                Name = "Arbitrary Payment"
+            };
+
+            var second = first.Copy();
+
+            Assert.AreNotSame(first, second);
+            Assert.IsTrue(first.Equals(second));
+            Assert.IsTrue(second.Equals(first));
+        }
     }
 }

--- a/Tests/Unit Tests/MyHome.DataClasses.Tests/ExtensionsTests.cs
+++ b/Tests/Unit Tests/MyHome.DataClasses.Tests/ExtensionsTests.cs
@@ -61,5 +61,37 @@ namespace MyHome.DataClasses.Tests
             Assert.IsTrue(first.Equals(second));
             Assert.IsTrue(second.Equals(first));
         }
+
+        [TestMethod]
+        public void ExpenseCategory_Copy()
+        {
+            var first = new ExpenseCategory
+            {
+                Id = 1,
+                Name = "Arbitrary Expense"
+            };
+
+            var second = first.Copy();
+
+            Assert.AreNotSame(first, second);
+            Assert.IsTrue(first.Equals(second));
+            Assert.IsTrue(second.Equals(first));
+        }
+
+        [TestMethod]
+        public void IncomeCategory_Copy()
+        {
+            var first = new IncomeCategory
+            {
+                Id = 1,
+                Name = "Arbitrary Income"
+            };
+
+            var second = first.Copy();
+
+            Assert.AreNotSame(first, second);
+            Assert.IsTrue(first.Equals(second));
+            Assert.IsTrue(second.Equals(first));
+        }
     }
 }


### PR DESCRIPTION
Adding shallow copy methods for the ExpenseCategory and IncomeCategory classes - as well as accompanying unit tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-zuber/myhome/117)
<!-- Reviewable:end -->
